### PR TITLE
Some minor changes for issue #4

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,9 @@ redis.connect().then(() => {
       title: username,
       feed_url: req.protocol + '://' + req.get('host') + req.originalUrl,
       site_url: `https://twitter.com/${username}`,
+      custom_namespaces: {
+        atom: 'http://www.w3.org/2005/Atom'
+      }
     });
 
     for (const tweet of result.tweets) {
@@ -56,7 +59,7 @@ redis.connect().then(() => {
       const mediaUrls = tweet.legacy.entities.media?.map((media: any) => media.media_url_https) ?? [];
 
       feed.item({
-        title: url,
+        title: text,
         url: url,
         date,
         description: [


### PR DESCRIPTION
 I checked the RSS feed in Slack and some other readers (firefox and chrome plugins, and desktop readers like NewsFlow and RSS OWL).

Minor changes 

- Added the XML namespace declaration (xmlns:atom="http://www.w3.org/2005/Atom") to properly use the atom:link element later.
- Put the tweet in the title **and** description 

Originally had the link in the title which was a mess, putting the tweet in the title makes sure readers cut off text on their own Gui. Looked much better.
![afbeelding](https://github.com/12joan/twitter-client/assets/3026022/fdd79ece-2056-4a77-8dd2-41d126251541)

![afbeelding](https://github.com/12joan/twitter-client/assets/3026022/ad206ad4-cfa6-4cbe-8f45-3dade6a388f2)

