### PR TITLE
extend flavour

### DIFF
--- a/src/feed_item_default.ts
+++ b/src/feed_item_default.ts
@@ -1,0 +1,15 @@
+const id = tweet.rest_id;
+const url = `https://twitter.com/${username}/status/${id}`;
+const date = tweet.legacy.created_at;
+const text = tweet.legacy.full_text;
+const mediaUrls = tweet.legacy.entities.media?.map((media) => media.media_url_https) ?? [];
+
+feed.item({
+    title: text,
+    url: url,
+    date,
+    description: [
+	text,
+        ...mediaUrls.map((url) => `<img src="${url}" />`),
+    ].join('\n'),
+});

--- a/src/feed_item_slack.ts
+++ b/src/feed_item_slack.ts
@@ -1,0 +1,15 @@
+const id = tweet.rest_id;
+const url = `https://twitter.com/${username}/status/${id}`;
+const date = tweet.legacy.created_at;
+const text = tweet.legacy.full_text;
+const mediaUrls = tweet.legacy.entities.media?.map((media) => media.media_url_https) ?? [];
+
+feed.item({
+    title: url,
+    url: url,
+    date,
+    description: [
+	text,
+        ...mediaUrls.map((url: string) => url),
+    ].join('\n'),
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { createClient as createRedisClient } from 'redis';
 import RSS from 'rss';
 import { fetchTweets } from './twitter';
+import fs from 'fs';
 
 const redis = createRedisClient({ url: process.env.REDIS_URL });
 redis.on('error', console.error);
@@ -56,26 +57,7 @@ redis.connect().then(() => {
     });
 
     for (const tweet of result.tweets) {
-      const id = tweet.rest_id;
-      const url = `https://twitter.com/${username}/status/${id}`;
-      const date = tweet.legacy.created_at;
-      const text = tweet.legacy.full_text;
-      const mediaUrls = tweet.legacy.entities.media?.map((media: any) => media.media_url_https) ?? [];
-
-      feed.item({
-        title: flavour === 'slack'
-          ? url
-          : text,
-        url: url,
-        date,
-        description: [
-          text,
-          ...mediaUrls.map((url: string) => flavour === 'slack'
-            ? url
-            : `<img src="${url}" />`
-          ),
-        ].join('\n'),
-      });
+      eval(fs.readFileSync('./src/feed_item_' + flavour + '.ts', 'utf-8'));
     }
 
     res.set('Content-Type', 'application/rss+xml');


### PR DESCRIPTION
This will extend `flavour` to be in external file, so it will be ease to add custom fields in items like these, without touching code itself:
```
feed.item({
    title: text,
    url: url,
    date,
    description: [
	text,
        ...mediaUrls.map((url) => `<img src="${url}" />`),
    ].join('\n'),
    'custom_elements': [
	{ 'name': tweet.core.user_results.result.legacy.screen_name },
	{ 'fullname': tweet.core.user_results.result.legacy.name },
	{ 'id': '' },
	{ 'avatar': tweet.core.user_results.result.legacy.profile_image_url_https }
    ]
});
```

File name must be: `feed_item_${flavour}.ts`

Please note, that `flavour` is not sanitized, so it can lead to some nasty things, but I'm no too lazy, so you are warned!
