### PR TITLE
filters out tweets where username does not match screen_name

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -56,29 +56,27 @@ redis.connect().then(() => {
     });
 
     for (const tweet of result.tweets) {
-      if( username === tweet.core.user_results.result.legacy.screen_name ) {
-        const id = tweet.rest_id;
-        const url = `https://twitter.com/${username}/status/${id}`;
-        const date = tweet.legacy.created_at;
-        const text = tweet.legacy.full_text;
-        const mediaUrls = tweet.legacy.entities.media?.map((media: any) => media.media_url_https) ?? [];
+      const id = tweet.rest_id;
+      const url = `https://twitter.com/${username}/status/${id}`;
+      const date = tweet.legacy.created_at;
+      const text = tweet.legacy.full_text;
+      const mediaUrls = tweet.legacy.entities.media?.map((media: any) => media.media_url_https) ?? [];
 
-        feed.item({
-          title: flavour === 'slack'
+      feed.item({
+        title: flavour === 'slack'
+          ? url
+          : text,
+        url: url,
+        date,
+        custom_elements: [{ 'dc:creator': username }],
+        description: [
+          text,
+          ...mediaUrls.map((url: string) => flavour === 'slack'
             ? url
-            : text,
-          url: url,
-          date,
-          custom_elements: [{ 'dc:creator': tweet.core.user_results.result.legacy.screen_name }],
-          description: [
-            text,
-            ...mediaUrls.map((url: string) => flavour === 'slack'
-              ? url
-              : `<img src="${url}" />`
-            ),
-          ].join('\n'),
-        });
-      }
+            : `<img src="${url}" />`
+          ),
+        ].join('\n'),
+      });
     }
 
     res.set('Content-Type', 'application/rss+xml');

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,27 +56,29 @@ redis.connect().then(() => {
     });
 
     for (const tweet of result.tweets) {
-      const id = tweet.rest_id;
-      const url = `https://twitter.com/${username}/status/${id}`;
-      const date = tweet.legacy.created_at;
-      const text = tweet.legacy.full_text;
-      const mediaUrls = tweet.legacy.entities.media?.map((media: any) => media.media_url_https) ?? [];
+      if( username === tweet.core.user_results.result.legacy.screen_name ) {
+        const id = tweet.rest_id;
+        const url = `https://twitter.com/${username}/status/${id}`;
+        const date = tweet.legacy.created_at;
+        const text = tweet.legacy.full_text;
+        const mediaUrls = tweet.legacy.entities.media?.map((media: any) => media.media_url_https) ?? [];
 
-      feed.item({
-        title: flavour === 'slack'
-          ? url
-          : text,
-        url: url,
-        date,
-        custom_elements: [{ 'dc:creator': username }],
-        description: [
-          text,
-          ...mediaUrls.map((url: string) => flavour === 'slack'
+        feed.item({
+          title: flavour === 'slack'
             ? url
-            : `<img src="${url}" />`
-          ),
-        ].join('\n'),
-      });
+            : text,
+          url: url,
+          date,
+          custom_elements: [{ 'dc:creator': tweet.core.user_results.result.legacy.screen_name }],
+          description: [
+            text,
+            ...mediaUrls.map((url: string) => flavour === 'slack'
+              ? url
+              : `<img src="${url}" />`
+            ),
+          ].join('\n'),
+        });
+      }
     }
 
     res.set('Content-Type', 'application/rss+xml');

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -162,9 +162,6 @@ export const fetchTweets = async (redis: RedisClient, username: string): Promise
           },
         }).then(res => res.json());
 
-//const dumpstring = JSON.stringify(data, null, 2);
-//console.log(dumpstring);
-
         return {
           ok: true,
           tweets: data.data.user.result.timeline_v2.timeline.instructions

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -169,8 +169,11 @@ export const fetchTweets = async (redis: RedisClient, username: string): Promise
             .flatMap((instruction: any) => instruction.entries)
             .map((entry: any) => entry?.content?.itemContent?.tweet_results?.result)
             .filter((tweet: any) => tweet)
-            //only accept tweets whose screen_name actually matches :username
-            //  it may be a bug or it may be advertising, but incorrect tweets have been showing up on this API endpoint
+            /**
+             * Only accept Tweets whose screen_name matches username. It may be
+             * a bug or it may be advertising, but incorrect Tweets have been
+             * showing up on this API endpoint.
+             */
             .filter((tweet: any) => tweet.core.user_results.result.legacy.screen_name === username)
         };
       }),

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -162,6 +162,9 @@ export const fetchTweets = async (redis: RedisClient, username: string): Promise
           },
         }).then(res => res.json());
 
+//const dumpstring = JSON.stringify(data, null, 2);
+//console.log(dumpstring);
+
         return {
           ok: true,
           tweets: data.data.user.result.timeline_v2.timeline.instructions
@@ -169,6 +172,9 @@ export const fetchTweets = async (redis: RedisClient, username: string): Promise
             .flatMap((instruction: any) => instruction.entries)
             .map((entry: any) => entry?.content?.itemContent?.tweet_results?.result)
             .filter((tweet: any) => tweet)
+            //only accept tweets whose screen_name actually matches :username
+            //  it may be a bug or it may be advertising, but incorrect tweets have been showing up on this API endpoint
+            .filter((tweet: any) => tweet.core.user_results.result.legacy.screen_name === username)
         };
       }),
     )


### PR DESCRIPTION
Fixes #16 

this only inserts tweets in rss if the request's username matches the tweet's tweet.core.user_results.result.legacy.screen_name

I'm running this patch on my server (<https://twitter.oksocial.net/main/public>) now; I haven't gotten any wrongly-timelined tweets yet.